### PR TITLE
Update urbanflow.py

### DIFF
--- a/lettuce/ext/_flows/urbanflow.py
+++ b/lettuce/ext/_flows/urbanflow.py
@@ -118,7 +118,7 @@ class UrbanFlow(ExtFlow):
         ux_in = self.ux[0, :, :][None, :, :]
         u_in = torch.stack((ux_in, torch.zeros_like(ux_in), torch.zeros_like(ux_in)), 0)
         
-        ux_top_in = self.ux[-1, :, :][None, :, :]
+        ux_top_in = self.ux[0, :, -1][None, :, None]
         u_top_in = torch.stack((ux_top_in, torch.zeros_like(ux_in), torch.zeros_like(ux_in)), 0)
         
         return [


### PR DESCRIPTION
Vorher hast Du von self.ux die _hinterste_ (1. Dimension `-1`) Fläche genommen. Du willst aber schon die _vorderste_ Fläche und davon die _höchste_ (3. Dimension) Zeile. Mit anschließendem `[None, :, None]` sollte torch den Broadcast auf 3D hinkriegen.